### PR TITLE
feat: improve error handling across entire frontend

### DIFF
--- a/src/components/hospital/NearbyHospital.tsx
+++ b/src/components/hospital/NearbyHospital.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const NearbyHospitals = ({ triggerLocation = 0 }: Props) => {
-    const { hospitals, loading, message } = useNearbyHospitals({ triggerLocation });
+    const { hospitals, loading, message, error, retry } = useNearbyHospitals({ triggerLocation });
     const navigate = useNavigate();
 
     return (
@@ -23,6 +23,11 @@ const NearbyHospitals = ({ triggerLocation = 0 }: Props) => {
                         <>
                             <FiNavigation className={style.pulse} />
                             <span>{message}</span>
+                            {error && (
+                                <button onClick={retry} className={style.retryBtn}>
+                                    Retry
+                                </button>
+                            )}
                         </>
                     )}
                 </div>

--- a/src/components/hospital/PopularHospitals.tsx
+++ b/src/components/hospital/PopularHospitals.tsx
@@ -12,25 +12,20 @@ const PopularHospitals = () => {
   const [hospitals, setHospitals] = useState<Hospital[]>([]);
   const [error, setError] = useState<string>("");
 
+  const loadHospitals = async () => {
+    try {
+      const response = await getRandomHospitals();
+      setHospitals(response);
+      setError("");
+    } catch (err: any) {
+      if (err.response) setError(err.response.data?.message || "Server error");
+      else if (err.request) setError("Unable to load recommended hospitals at this time.");
+      else setError(err.message);
+    }
+  };
+
   useEffect(() => {
-    let mounted = true;
-
-    const fetchRandomHospitals = async () => {
-      try {
-        const response = await getRandomHospitals();
-        if (mounted) setHospitals(response);
-      } catch (err: any) {
-        if (mounted) {
-          if (err.data) setError(err.message);
-          else if (err.request) setError("Unable to load recommended hospitals at this time.");
-          else setError(err.message);
-        }
-      }
-    };
-
-    fetchRandomHospitals();
-
-    return () => { mounted = false; };
+    loadHospitals();
   }, []);
 
   if (hospitals.length === 0 && !error) return null;
@@ -49,7 +44,12 @@ const PopularHospitals = () => {
         </p>
       </Motion>
 
-      {error && <p className={style.error}>{error}</p>}
+      {error && (
+        <div className={style.errorContainer}>
+          <p className={style.error}>{error}</p>
+          <button onClick={loadHospitals} className={style.retryBtn}>Try Again</button>
+        </div>
+      )}
 
       {hospitals.length > 0 && (
         <Motion variants={sectionReveal} className={style.wrapper}>

--- a/src/components/hospital/ShareHospitalList.tsx
+++ b/src/components/hospital/ShareHospitalList.tsx
@@ -3,7 +3,7 @@ import { useSharedHospitals } from "@/hooks/useSharedHospitals";
 import { Avatar } from "@/components/ui/Avatar";
 import AnimatedLoader from "@/components/ui/AnimatedLoader";
 import HospitalPic from "@/assets/images/hospital-logo.jpg";
-import style from "./styles/popular.module.css";
+import style from "./styles/shareHospitalList.module.css";
 import { SEOHelmet } from "../ui/SeoHelmet";
 
 const ShareHospitalList = () => {

--- a/src/components/hospital/hospitalDetails.tsx
+++ b/src/components/hospital/hospitalDetails.tsx
@@ -24,7 +24,7 @@ const HospitalDetails = () => {
     const { state } = useAuthContext();
     const navigate = useNavigate();
     const [isExiting, setIsExiting] = useState(false);
-    const { hospital, loading, isFavorite, toggleFavorite } = useHospitalDetails({
+    const { hospital, loading, error, retry, isFavorite, toggleFavorite } = useHospitalDetails({
         id, country, city, slug, name,
         accessToken: state?.accessToken,
         username: state?.username
@@ -69,6 +69,19 @@ const HospitalDetails = () => {
                 imageHeight={200}
                 showButtons={false}
             />
+        );
+    }
+
+    if (error) {
+        return (
+            <div className={style.errorContainer}>
+                <div className={style.errorCard}>
+                    <MdErrorOutline size={60} className={style.errorIcon} />
+                    <h2 className={style.errorTitle}>Unable to Load Facility</h2>
+                    <p className={style.errorText}>{error}</p>
+                    <button onClick={retry} className={style.errorBtn}>Try Again</button>
+                </div>
+            </div>
         );
     }
 

--- a/src/components/hospital/styles/nearbyHospital.module.css
+++ b/src/components/hospital/styles/nearbyHospital.module.css
@@ -31,7 +31,22 @@
 .pulse {
   color: var(--color-blue);
   animation: pulse-animation 2s infinite;
-  /* font-size: 3rem; */
+}
+
+.retryBtn {
+  background: none;
+  border: none;
+  color: var(--color-blue);
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 0.9rem;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  padding: 0;
+}
+
+.retryBtn:hover {
+  opacity: 0.8;
 }
 
 .textLink {

--- a/src/components/hospital/styles/shareHospitalList.module.css
+++ b/src/components/hospital/styles/shareHospitalList.module.css
@@ -1,45 +1,11 @@
-.container {
+.sharePage {
+  width: 100%;
+  min-height: 80vh;
+  padding: 4rem 2rem;
+  background-color: var(--color-bg);
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  width: 100%;
-  padding: 1rem 1.5rem;
-  background-color: var(--color-bg-light);
-  border-radius: 1rem;
-  text-align: center;
-}
-
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-}
-
-.heading {
-  font-size: 1.8rem;
-  font-weight: 700;
-  letter-spacing: -0.02rem;
-  line-height: 1.2;
-  color: var(--color-blue);
-  margin-bottom: 0.5rem;
-  font-family: var(--font-plus);
-}
-
-.subtitle {
-  font-size: 1.2rem;
-  font-weight: 400;
-  color: var(--color-gray);
-  margin: 0 auto 2.5rem;
-  max-width: 60ch;
-  line-height: 1.6;
-  font-family: var(--font-inter);
 }
 
 .wrapper {
@@ -48,6 +14,16 @@
   gap: 2rem;
   width: 100%;
   max-width: 1200px;
+}
+
+.shareContent {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 1200px;
+  list-style: none;
+  padding: 5rem 1rem 1rem;
 }
 
 .card {
@@ -70,28 +46,18 @@
   border-color: var(--color-blue-light);
 }
 
-.imgContainer {
+.shareImg {
+  height: 200px;
   width: 100%;
-  aspect-ratio: 16 / 9;
   overflow: hidden;
-  background-color: var(--color-ash);
+  border-radius: 1.2rem;
+  margin-bottom: 1rem;
 }
 
-.imgContainer img {
+.shareAvatar {
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  transition: transform 0.5s ease;
-}
-
-.imgContainer:hover img {
-  transform: scale(1.05);
-}
-
-.avatar {
-  width: 100%;
-  height: 100%;
-  border-radius: 0;
+  border-radius: 1.2rem;
   object-fit: cover;
 }
 
@@ -147,49 +113,30 @@
 
 .error {
   color: var(--color-error);
-  font-size: 1rem;
+  font-size: 1.2rem;
   font-weight: 500;
   width: 100%;
+  max-width: 600px;
   padding: 1rem;
   background: #fee2e2;
   border-radius: 8px;
+  text-align: center;
+  margin-top: 5rem;
+  margin-bottom: 1rem;
 }
 
-.errorContainer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-  margin-top: 1rem;
-}
-
-.retryBtn {
-  background: var(--color-black);
-  color: var(--color-white);
-  border: none;
-  padding: 0.5rem 1.5rem;
-  border-radius: 8px;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  transition: opacity 0.2s;
-}
-
-.retryBtn:hover {
-  opacity: 0.8;
-}
-
-@media (min-width: 48em) {
-  .heading {
-    font-size: 2rem;
+@media (max-width: 768px) {
+  .sharePage {
+    padding: 2rem 1rem;
   }
-  .subtitle {
-    font-size: 1.1rem;
+  .shareContent {
+    gap: 1.5rem;
+    padding: 2rem 0.5rem 1rem;
   }
-}
 
-@media (min-width: 75em) {
-  .heading {
-    font-size: 2.25rem;
+  .error {
+    font-size: 1rem;
+    padding: 0.75rem;
+    margin-top: 10rem;
   }
 }

--- a/src/hooks/useAdminDashboard.ts
+++ b/src/hooks/useAdminDashboard.ts
@@ -17,7 +17,7 @@ export const useAdminDashboard = () => {
         try {
             setLoading(true);
             setError(null);
-            const response = await axiosPrivate.get("/hospitals/admin/stats");
+            const response = await axiosPrivate.get("/hospitals/admin/stats", { skipErrorToast: true } as any);
             setStats(response.data);
         } catch (err: any) {
             console.error("Dashboard Stats Error:", err);

--- a/src/hooks/useAdminHospitals.ts
+++ b/src/hooks/useAdminHospitals.ts
@@ -11,7 +11,7 @@ export const useAdminHospitals = () => {
     const fetchHospitals = useCallback(async () => {
         try {
             setIsLoading(true);
-            const response = await axiosPrivate.get("/admin/hospitals");
+            const response = await axiosPrivate.get("/admin/hospitals", { skipErrorToast: true } as any);
             setHospitals(response.data);
         } catch (err: any) {
             toast.error(err?.response?.data?.message || "Failed to securely load the hospital directory.");
@@ -23,10 +23,10 @@ export const useAdminHospitals = () => {
     const submitHospital = async (isEditing: boolean, selectedId: string | null, formData: HospitalFormData) => {
         try {
             if (isEditing && selectedId) {
-                await axiosPrivate.patch(`/hospitals/${selectedId}`, formData);
+                await axiosPrivate.patch(`/hospitals/${selectedId}`, formData, { skipErrorToast: true } as any);;
                 toast.success("Hospital record securely updated.");
             } else {
-                await axiosPrivate.post("/hospitals", formData);
+                await axiosPrivate.post("/hospitals", formData, { skipErrorToast: true } as any);
                 toast.success("New hospital securely added to the directory.");
             }
             await fetchHospitals();
@@ -39,7 +39,7 @@ export const useAdminHospitals = () => {
 
     const toggleStatus = async (id: string) => {
         try {
-            await axiosPrivate.patch(`/admin/hospitals/${id}/toggle-status`);
+            await axiosPrivate.patch(`/admin/hospitals/${id}/toggle-status`,  {}, { skipErrorToast: true } as any);
             toast.success("Hospital verification status updated.");
             await fetchHospitals();
         } catch (err: any) {
@@ -49,7 +49,7 @@ export const useAdminHospitals = () => {
 
     const removeHospital = async (id: string) => {
         try {
-            await axiosPrivate.delete(`/hospitals/${id}`);
+            await axiosPrivate.delete(`/hospitals/${id}`, { skipErrorToast: true } as any);;
             toast.success("Hospital record permanently removed.");
             await fetchHospitals();
         } catch (err: any) {

--- a/src/hooks/useAdminPending.ts
+++ b/src/hooks/useAdminPending.ts
@@ -11,7 +11,7 @@ export const useAdminPending = () => {
     const getPendingHospitals = useCallback(async () => {
         try {
             setIsLoading(true);
-            const response = await axiosPrivate.get(`/admin/hospitals/pending`);
+            const response = await axiosPrivate.get(`/admin/hospitals/pending`, { skipErrorToast: true } as any);
             setHospitals(response.data);
         } catch (err: any) {
             toast.error(err.response?.data?.message || "Failed to load pending queue");
@@ -22,7 +22,7 @@ export const useAdminPending = () => {
 
     const approveHospital = async (id: string) => {
         try {
-            await axiosPrivate.patch(`/admin/hospitals/approve/${id}`);
+            await axiosPrivate.patch(`/admin/hospitals/approve/${id}`, {}, { skipErrorToast: true } as any);
             setHospitals((prev) => prev.filter((h) => h._id !== id));
             toast.success("Hospital approved and is now live!");
             return true;
@@ -36,8 +36,8 @@ export const useAdminPending = () => {
         try {
             await axiosPrivate.patch(
                 `/admin/hospitals/approve/${hospital._id}`,
-                hospital
-            );
+                hospital,
+                { skipErrorToast: true } as any);
             setHospitals((prev) => prev.filter((h) => h._id !== hospital._id));
             toast.success("Entry corrected and published live!");
             return true;
@@ -49,7 +49,7 @@ export const useAdminPending = () => {
 
     const batchApprove = async (ids: string[]) => {
   try {
-    const { data } = await axiosPrivate.patch("/admin/hospitals/approve-batch", { ids });
+    const { data } = await axiosPrivate.patch("/admin/hospitals/approve-batch", { ids }, { skipErrorToast: true } as any);
     setHospitals((prev) => prev.filter((h) => !ids.includes(h._id)));
     toast.success(data.message || "Hospitals approved!");
   } catch (err: any) {
@@ -59,7 +59,7 @@ export const useAdminPending = () => {
 
     const deleteSubmission = async (id: string) => {
         try {
-            await axiosPrivate.delete(`/admin/hospitals/${id}`);
+            await axiosPrivate.delete(`/admin/hospitals/${id}`, { skipErrorToast: true } as any);;
             setHospitals((prev) => prev.filter((h) => h._id !== id));
             toast.info("Submission rejected and removed.");
             return true;

--- a/src/hooks/useAdminUsers.ts
+++ b/src/hooks/useAdminUsers.ts
@@ -11,7 +11,7 @@ export const useAdminUsers = () => {
     const fetchUsers = useCallback(async () => {
         try {
             setIsLoading(true);
-            const response = await axiosPrivate.get("/admin/users");
+            const response = await axiosPrivate.get("/admin/users", { skipErrorToast: true } as any);
             setUsers(response.data);
         } catch (err) {
             console.error("Failed to fetch users", err);
@@ -27,7 +27,7 @@ export const useAdminUsers = () => {
 
     const createUser = async (formData: any): Promise<boolean> => {
         try {
-            await axiosPrivate.post("/admin/users", formData);
+            await axiosPrivate.post("/admin/users", formData, { skipErrorToast: true } as any);
             toast.success("User created successfully!");
             await fetchUsers();
             return true;
@@ -42,9 +42,9 @@ export const useAdminUsers = () => {
         if (!window.confirm(`Are you sure you want to change this user to ${newRole.toUpperCase()}?`)) return;
 
         try {
-            await axiosPrivate.patch("/admin/users/role", { userId, newRole });
+            await axiosPrivate.patch("/admin/users/role", { userId, newRole }, { skipErrorToast: true } as any);
             toast.success(`Role updated to ${newRole}`);
-            await fetchUsers(); // Refresh to guarantee UI matches database
+            await fetchUsers();
         } catch (err) {
             toast.error("Failed to update user role securely.");
         }
@@ -52,7 +52,7 @@ export const useAdminUsers = () => {
 
     const toggleStatus = async (userId: string) => {
         try {
-            const response = await axiosPrivate.patch(`/admin/users/${userId}`);
+            const response = await axiosPrivate.patch(`/admin/users/${userId}`,  {}, { skipErrorToast: true } as any);
             const newStatus = response.data.isActive;
             setUsers(prevUsers =>
                 prevUsers.map(user =>
@@ -69,7 +69,7 @@ export const useAdminUsers = () => {
     const deleteUser = async (id: string, username: string) => {
         if (!window.confirm(`PERMANENTLY DELETE ${username}? This cannot be undone.`)) return;
         try {
-            await axiosPrivate.delete(`/admin/users/${id}`);
+            await axiosPrivate.delete(`/admin/users/${id}`, { skipErrorToast: true } as any);;
             setUsers(prev => prev.filter(u => u._id !== id));
             toast.success("User permanently removed from the system.");
         } catch (err) {

--- a/src/hooks/useAgent.ts
+++ b/src/hooks/useAgent.ts
@@ -83,10 +83,10 @@ export const useAgent = () => {
           .filter((m) => !(m.role === 'assistant' && m.content.startsWith('👋')))
           .map(({ role, content }) => ({ role, content }));
 
-        const { data } = await axiosPrivate.post<ChatResponse>('/agent/chat', {
-          messages: apiMessages,
-          userLocation,
-        });
+        const { data } = await axiosPrivate.post<ChatResponse>('/agent/chat',
+          { messages: apiMessages, userLocation },
+          { skipErrorToast: true } as any
+      );
 
         if (data.type === 'MATCH_READY' && data.profile) {
           await runMatch(data.profile, updatedMessages);
@@ -133,7 +133,9 @@ export const useAgent = () => {
           symptoms: profile.symptoms,
           location: profile.location,
           additionalNeeds: profile.additionalNeeds,
-        });
+        },
+        { skipErrorToast: true } as any
+      );
 
         if (data.noResults) {
           setState((prev) => ({

--- a/src/hooks/useAuth0Handshake.ts
+++ b/src/hooks/useAuth0Handshake.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import axios from "axios";
 import { useNavigate } from "react-router-dom";
-import { useAuthContext, BASE_URL } from "@/context/UserProvider";
+import { useAuthContext } from "@/context/UserProvider";
+import { api } from "@/services/api";
 import { IdToken } from "@/types/auth";
 
 export const useAuth0Handshake = () => {
@@ -12,16 +12,15 @@ export const useAuth0Handshake = () => {
 
   const handleCallback = async (idToken: IdToken) => {
     try {
-      const response = await axios.post(
-        `${BASE_URL}/auth/auth0`,
+      const response = await api.post(
+        "/auth/auth0",
         {
           name: idToken.name,
           username: idToken.nickname,
           email: idToken.email,
           idToken: idToken.__raw,
         },
-        { withCredentials: true }
-      );
+        { skipErrorToast: true } as any);
 
       const authData = response.data;
 

--- a/src/hooks/useAxiosPrivate.ts
+++ b/src/hooks/useAxiosPrivate.ts
@@ -1,6 +1,5 @@
-import axios from "axios";
 import { useEffect } from "react";
-import { useAuthContext, BASE_URL } from "@/context/UserProvider";
+import { useAuthContext } from "@/context/UserProvider";
 import { api } from "@/services/api";
 
 const useAxiosPrivate = () => {
@@ -30,9 +29,7 @@ const useAxiosPrivate = () => {
                     prevRequest._retry = true;
 
                     try {
-                        const response = await axios.get(`${BASE_URL}/auth/refresh`, {
-                            withCredentials: true,
-                        });
+                        const response = await api.get("/auth/refresh", { skipErrorToast: true } as any);
 
                         const { accessToken, ...otherData } = response.data;
 

--- a/src/hooks/useCheckDuplicateHospital.ts
+++ b/src/hooks/useCheckDuplicateHospital.ts
@@ -16,8 +16,8 @@ export const useCheckDuplicateHospital = () => {
         setDupCheckLoading(true);
         try {
             const { data } = await axiosPrivate.get(
-                `/hospitals/check-duplicate?name=${encodeURIComponent(name)}&city=${encodeURIComponent(city)}&currentId=${currentId || ""}`
-            );
+                `/hospitals/check-duplicate?name=${encodeURIComponent(name)}&city=${encodeURIComponent(city)}&currentId=${currentId || ""}`,
+                { skipErrorToast: true } as any);
 
         if (data.isDuplicate) {
                  toast.error(data.message, {  icon: () => React.createElement(FiAlertTriangle)});

--- a/src/hooks/useCountryHospitals.ts
+++ b/src/hooks/useCountryHospitals.ts
@@ -9,6 +9,7 @@ export const useCountryHospitals = (country: string | undefined) => {
   const [totalPages, setTotalPages] = useState<number>(1);
   const [fetchingMore, setFetchingMore] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [retryCounter, setRetryCounter] = useState(0);
 
   const decodedCountry = useMemo(() => decodeURIComponent(country || ""), [country]);
 
@@ -41,13 +42,17 @@ export const useCountryHospitals = (country: string | undefined) => {
 
   useEffect(() => {
     fetchHospitals();
-  }, [fetchHospitals]);
+  }, [fetchHospitals, retryCounter]);
 
   const loadMore = useCallback(() => {
     if (!loading && !fetchingMore && page < totalPages) {
       setPage((p) => p + 1);
     }
   }, [loading, fetchingMore, page, totalPages]);
+
+  const retry = useCallback(() => {
+  setRetryCounter((c) => c + 1);
+}, []);
 
   return {
     hospitals,
@@ -57,6 +62,7 @@ export const useCountryHospitals = (country: string | undefined) => {
     page,
     decodedCountry,
     error,
+    retry,
     loadMore
   };
 };

--- a/src/hooks/useDeleteUser.ts
+++ b/src/hooks/useDeleteUser.ts
@@ -17,7 +17,8 @@ const useDelete = () => {
     try {
       await axiosPrivate.delete(`/user`, {
         data: { username, password },
-      });
+        skipErrorToast: true,
+       } as any);
 
       dispatch({ type: 'DELETE' });
       localStorage.clear();

--- a/src/hooks/useForgotPassword.ts
+++ b/src/hooks/useForgotPassword.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
-import axios from "axios";
 import { toast } from "react-toastify";
-import {BASE_URL} from "@/context/UserProvider"
+import { api } from "@/services/api";
 
 
 export const useForgotPassword = () => {
@@ -10,7 +9,7 @@ export const useForgotPassword = () => {
   const sendResetLink = async (email: string) => {
     setLoading(true);
     try {
-      await axios.post(`${BASE_URL}/auth/forgot-password`, { email });
+      await api.post("/auth/forgot-password", { email }, { skipErrorToast: true } as any);
       toast.success("Reset link sent! Check your email.");
       return true;
     } catch (error: any) {

--- a/src/hooks/useGlobalDirectory.ts
+++ b/src/hooks/useGlobalDirectory.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback  } from "react";
 import { CountryData, CountryListEntry, } from "@/types/hospital";
 import { BASE_URL } from "@/context/UserProvider";
 import { normalizeName } from "@/utils/formatters";
@@ -15,6 +15,7 @@ export const useGlobalDirectory = () => {
   const [countries, setCountries] = useState<CountryData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retryCounter, setRetryCounter] = useState(0);
 
   useEffect(() => {
     const fetchCountries = async () => {
@@ -32,7 +33,7 @@ export const useGlobalDirectory = () => {
       }
     };
     fetchCountries();
-  }, []);
+  }, [retryCounter]);
 
   const getContinent = (countryName: string) => {
     const cleanName = countryName.trim();
@@ -75,5 +76,9 @@ export const useGlobalDirectory = () => {
     return Array.from(map.values());
   }, [countries]);
 
-  return { unifiedCountries, loading, error };
+  const retry = useCallback(() => {
+  setRetryCounter(c => c + 1);
+}, []);
+
+  return { unifiedCountries, loading, error, retry  };
 };

--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
-import { BASE_URL } from "@/context/UserProvider";
-import {GlobalStats} from "@/types/app";
+import { useState, useEffect, useCallback  } from "react";
+import { api } from "@/services/api";
+import { GlobalStats } from "@/types/app";
 
 export const useGlobalStats = () => {
   const [stats, setStats] = useState<GlobalStats>({
@@ -9,6 +9,11 @@ export const useGlobalStats = () => {
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [retryCounter, setRetryCounter] = useState(0);
+
+const retry = useCallback(() => {
+  setRetryCounter((c) => c + 1);
+}, []);
 
   useEffect(() => {
     const fetchGlobalStats = async () => {
@@ -17,22 +22,14 @@ export const useGlobalStats = () => {
         setError(false);
 
         const [countRes, countryRes] = await Promise.all([
-          fetch(`${BASE_URL}/hospitals/count`),
-          fetch(`${BASE_URL}/hospitals/stats/countries`)
+          api.get("/hospitals/count", { skipErrorToast: true } as any),
+          api.get("/hospitals/stats/countries", { skipErrorToast: true } as any)
         ]);
 
-        if (!countRes.ok || !countryRes.ok) {
-            throw new Error("Failed to securely fetch platform statistics.");
-        }
-
-        const countData = await countRes.json();
-        const countryData = await countryRes.json();
-
         setStats({
-          totalHospitals: countData.total,
-          totalCountries: countryData.length,
+          totalHospitals: countRes.data.total,
+          totalCountries: countryRes.data.length,
         });
-
       } catch (err) {
         console.error("Global Stats Sync Error:", err);
         setError(true);
@@ -43,7 +40,7 @@ export const useGlobalStats = () => {
     };
 
     fetchGlobalStats();
-  }, []);
+  }, [retryCounter]);
 
-  return { ...stats, loading, error };
+  return { ...stats, loading, error, retry  };
 };

--- a/src/hooks/useGoogleImport.ts
+++ b/src/hooks/useGoogleImport.ts
@@ -31,7 +31,7 @@ export const useGoogleImport = (onSuccess?: () => void) => {
       const { data } = await axiosPrivate.post("/admin/hospitals/import-google", {
         city: city.trim(),
         targetCountry: country.trim()
-      });
+      }, { skipErrorToast: true } as any);
 
       setResult(data);
       toast.success(`Success! Added ${data.imported} locations with rich data.`);

--- a/src/hooks/useHealthHistory.ts
+++ b/src/hooks/useHealthHistory.ts
@@ -12,7 +12,7 @@ export const useHealthHistory = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const { data } = await axiosPrivate.get('/user/health-history');
+      const { data } = await axiosPrivate.get('/user/health-history', { skipErrorToast: true } as any);
       setHistory(data.history || []);
     } catch (err: any) {
       setError(err?.response?.data?.message || 'Failed to load health history');
@@ -30,8 +30,9 @@ export const useHealthHistory = () => {
       try {
         await axiosPrivate.patch(
           `/user/health-history/${sessionId}/feedback`,
-          payload
-        );
+          payload,
+          { skipErrorToast: true } as any);
+
         setHistory((prev) =>
           prev.map((s) =>
             s._id === sessionId
@@ -57,7 +58,7 @@ export const useHealthHistory = () => {
   const deleteSession = useCallback(
     async (sessionId: string) => {
       try {
-        await axiosPrivate.delete(`/user/health-history/${sessionId}`);
+        await axiosPrivate.delete(`/user/health-history/${sessionId}`, { skipErrorToast: true } as any);
         setHistory((prev) => prev.filter((s) => s._id !== sessionId));
         return { success: true };
       } catch (err: any) {
@@ -72,7 +73,7 @@ export const useHealthHistory = () => {
 
   const clearHistory = useCallback(async () => {
     try {
-      await axiosPrivate.delete('/user/health-history');
+      await axiosPrivate.delete('/user/health-history', { skipErrorToast: true } as any);
       setHistory([]);
       return { success: true };
     } catch (err: any) {

--- a/src/hooks/useHealthNews.ts
+++ b/src/hooks/useHealthNews.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { BASE_URL } from "@/context/UserProvider";
+import { api } from "@/services/api";
 import { Article, UseHealthNewsReturn} from "@/types/media";
 
 export const useHealthNews = (limit: number = 12): UseHealthNewsReturn => {
@@ -12,13 +12,9 @@ export const useHealthNews = (limit: number = 12): UseHealthNewsReturn => {
             setLoading(true);
             setError(null);
 
-            const res = await fetch(`${BASE_URL}/health/news`);
+            const response = await api.get("/health/news", { skipErrorToast: true } as any);
+            const data = response.data;
 
-            if (!res.ok) {
-                throw new Error(res.status === 404 ? "News service currently unavailable." : "Server error.");
-            }
-
-            const data = await res.json();
             const list = Array.isArray(data) ? data : (data.results || []);
 
             setArticles(list.slice(0, limit));

--- a/src/hooks/useHealthTips.ts
+++ b/src/hooks/useHealthTips.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { BASE_URL } from "@/context/UserProvider";
+import { api } from "@/services/api";
 import {Tip} from "@/types/media";
 
 export const useHealthTips = () => {
@@ -20,8 +20,8 @@ export const useHealthTips = () => {
         const fetchTips = async () => {
             try {
                 setLoading(true);
-                const res = await fetch(`${BASE_URL}/health/tips`);
-                const data = await res.json();
+                const response = await api.get("/health/tips", { skipErrorToast: true } as any);
+                const data = response.data;
 
                 if (Array.isArray(data) && data.length > 0) {
                     setTips(data);

--- a/src/hooks/useHospitalDetails.ts
+++ b/src/hooks/useHospitalDetails.ts
@@ -11,6 +11,7 @@ export const useHospitalDetails = ({
     const [loading, setLoading] = useState(true);
     const [isFavorite, setIsFavorite] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [retryCounter, setRetryCounter] = useState(0);
     const lastRecordedId = useRef<string | null>(null);
     const axiosPrivate = useAxiosPrivate();
     const userPrefix = username || "guest";
@@ -41,6 +42,10 @@ export const useHospitalDetails = ({
             }
         }
     }, [REC_KEY, accessToken, axiosPrivate]);
+
+    const retry = useCallback(() => {
+  setRetryCounter(c => c + 1);
+}, []);
 
     useEffect(() => {
         const fetchHospital = async () => {
@@ -81,7 +86,7 @@ export const useHospitalDetails = ({
         };
 
         fetchHospital();
-    }, [id, country, city, slug, name, FAV_KEY, addToHistory]);
+    }, [id, country, city, slug, name, FAV_KEY, addToHistory, retryCounter]);
 
     const toggleFavorite = async () => {
         if (!hospital) return;
@@ -114,5 +119,5 @@ export const useHospitalDetails = ({
         }
     };
 
-    return { hospital, loading, error, isFavorite, toggleFavorite };
+    return { hospital, loading, error, retry, isFavorite, toggleFavorite };
 };

--- a/src/hooks/useHospitalDiscovery.ts
+++ b/src/hooks/useHospitalDiscovery.ts
@@ -1,7 +1,6 @@
 import { useState, useCallback } from "react";
 import axios from "axios";
-import { BASE_URL } from "@/context/UserProvider";
-import { findHospitals } from "@/services/api";
+import { api } from "@/services/api";
 import { SearchState } from "@/types/hospital";
 import { accessToken } from "@/config/mapbox";
 
@@ -34,7 +33,8 @@ export const useHospitalDiscovery = () => {
                 return { data: [], displayString: "" };
             }
 
-            const data = await findHospitals(apiQuery);
+            const response = await api.get(`/hospitals/find?${apiQuery}`, { skipErrorToast: true } as any);
+            const data = response.data;
 
             if (!data || data.length === 0) {
                 let center: [number, number] | null = null;
@@ -73,8 +73,8 @@ export const useHospitalDiscovery = () => {
     const fetchNearby = useCallback(async (latitude: number, longitude: number) => {
         setState(prev => ({ ...prev, searching: true, error: "", emptyResultQuery: null }));
         try {
-            const response = await fetch(`${BASE_URL}/hospitals/nearby?lat=${latitude}&lng=${longitude}`);
-            const data = await response.json();
+            const response = await api.get(`/hospitals/nearby?lat=${latitude}&lng=${longitude}`, { skipErrorToast: true } as any);
+            const data = response.data;
             const results = data.results || [];
 
             let locName = null;

--- a/src/hooks/useHospitalInteractions.ts
+++ b/src/hooks/useHospitalInteractions.ts
@@ -34,7 +34,7 @@ export function useHospitalInteractions(
 
     if (state?.accessToken) {
       try {
-        await axiosPrivate.post(`/user/favorites-status/${h._id}`);
+        await axiosPrivate.post(`/user/favorites-status/${h._id}`, {}, { skipErrorToast: true } as any);
       } catch (error) {
         console.error("Sync failed", error);
       }
@@ -70,7 +70,7 @@ export function useHospitalInteractions(
 
     if (state?.accessToken) {
       try {
-        await axiosPrivate.post("/user/view", { hospitalId: hospital._id });
+        await axiosPrivate.post("/user/view", { hospitalId: hospital._id }, { skipErrorToast: true } as any);
       } catch (e) {
          console.error("View sync failed", e);
       }

--- a/src/hooks/useHospitalSearch.ts
+++ b/src/hooks/useHospitalSearch.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { Hospital } from "@/types/hospital";
-import { findHospitals } from "@/services/api";
-import { BASE_URL } from "@/context/UserProvider";
+import { api } from "@/services/api";
 
 export function useHospitalSearch() {
   const [hospitals, setHospitals] = useState<Hospital[]>([]);
@@ -14,9 +13,8 @@ export function useHospitalSearch() {
     let mounted = true;
     (async () => {
       try {
-        const res = await fetch(`${BASE_URL}/hospitals/explore/top`);
-        const data = await res.json();
-        if (mounted) setCountries(Array.isArray(data) ? data : []);
+        const response = await api.get("/hospitals/explore/top", { skipErrorToast: true } as any);
+          if (mounted) setCountries(Array.isArray(response.data) ? response.data : []);
       } catch {
         if (mounted) setCountries([]);
       } finally {
@@ -43,7 +41,8 @@ export function useHospitalSearch() {
       }
 
       if (url) {
-        const data = await findHospitals(url);
+        const response = await api.get(`/hospitals/find?${url}`, { skipErrorToast: true } as any);
+        const data = response.data;
 
         if (data && data.length > 0) {
           setHospitals(data);

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -17,7 +17,7 @@ const useLogin = () => {
     setSuccess(false);
 
     try {
-      const response = await api.post(`/auth`, credentials);
+      const response = await api.post(`/auth`, credentials, { skipErrorToast: true } as any);
       const data = response.data;
 
       dispatch({

--- a/src/hooks/useNearbyHospitals.ts
+++ b/src/hooks/useNearbyHospitals.ts
@@ -1,14 +1,20 @@
-import { useState, useEffect, useCallback } from "react";
-import { BASE_URL } from "@/context/UserProvider";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { api } from "@/services/api";
 import {NearbyHospital, UseNearbyHospitalsProps} from "@/types/hospital";
 
 export const useNearbyHospitals = ({ triggerLocation = 0 }: UseNearbyHospitalsProps) => {
     const [hospitals, setHospitals] = useState<NearbyHospital[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [message, setMessage] = useState<string>("Locating nearby services...");
+    const [error, setError] = useState(false);
+    const latRef = useRef<number | undefined>();
+    const lonRef = useRef<number | undefined>();
 
     const fetchHospitals = useCallback(async (lat?: number, lon?: number) => {
         setLoading(true);
+        setError(false);
+        latRef.current = lat;
+        lonRef.current = lon;
         try {
             const params = new URLSearchParams({ limit: "3" });
 
@@ -17,11 +23,8 @@ export const useNearbyHospitals = ({ triggerLocation = 0 }: UseNearbyHospitalsPr
                 params.append("lon", lon.toString());
             }
 
-            const res = await fetch(`${BASE_URL}/hospitals/nearby?${params.toString()}`);
-
-            if (!res.ok) throw new Error("API Request Failed");
-
-            const data = await res.json();
+            const response = await api.get(`/hospitals/nearby?${params.toString()}`, { skipErrorToast: true } as any);
+            const data = response.data;
             const results = Array.isArray(data) ? data : (data.results || []);
 
             setHospitals(results);
@@ -33,6 +36,7 @@ export const useNearbyHospitals = ({ triggerLocation = 0 }: UseNearbyHospitalsPr
             console.error("Proximity Fetch Error:", err);
             setMessage("Could not load hospitals. Please check your secure connection.");
             setHospitals([]);
+            setError(true);
         } finally {
             setLoading(false);
         }
@@ -62,5 +66,9 @@ export const useNearbyHospitals = ({ triggerLocation = 0 }: UseNearbyHospitalsPr
         }
     }, [triggerLocation, fetchHospitals]);
 
-    return { hospitals, loading, message };
+    const retry = useCallback(() => {
+    fetchHospitals(latRef.current, lonRef.current);
+  }, [fetchHospitals]);
+
+    return { hospitals, loading, message, error, retry  };
 };

--- a/src/hooks/useOsmImport.ts
+++ b/src/hooks/useOsmImport.ts
@@ -37,7 +37,7 @@ export const useOsmImport = (onSuccess?: () => void) => {
       const { data } = await axiosPrivate.post(url, {
         city: city.trim(),
         targetCountry: country.trim(),
-      });
+      },  { skipErrorToast: true } as any);
 
       if (dryRun) {
         setDryRunResult(data);

--- a/src/hooks/useOutbreaks.ts
+++ b/src/hooks/useOutbreaks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { BASE_URL } from "@/context/UserProvider";
+import { api } from "@/services/api";
 import { Alert, UseOutbreaksReturn} from "@/types/media";
 import {continentData} from "@/components/constants/outbreakConstants"
 
@@ -13,11 +13,9 @@ export const useOutbreaks = (): UseOutbreaksReturn => {
         try {
             setLoading(true);
             setError(null);
-            const res = await fetch(`${BASE_URL}/health/alerts`);
+            const response = await api.get("/health/alerts", { skipErrorToast: true } as any);
+            const data = response.data;
 
-            if (!res.ok) throw new Error("Could not retrieve alerts.");
-
-            const data = await res.json();
             const list = Array.isArray(data) ? data : (data.results || []);
             setAlerts(list);
         } catch (err) {

--- a/src/hooks/usePersistLogin.ts
+++ b/src/hooks/usePersistLogin.ts
@@ -1,7 +1,7 @@
-import axios from "axios";
 import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { useAuthContext, BASE_URL } from "@/context/UserProvider";
+import { useAuthContext } from "@/context/UserProvider";
+import { api } from "@/services/api";
 
 export const usePersistLogin = () => {
     const [isLoading, setIsLoading] = useState(true);
@@ -13,9 +13,7 @@ export const usePersistLogin = () => {
 
         const verifyRefreshToken = async () => {
             try {
-                const response = await axios.get(`${BASE_URL}/auth/refresh`, {
-                    withCredentials: true
-                });
+                const response = await api.get("/auth/refresh", { skipErrorToast: true } as any);
 
                 dispatch({
                     type: 'REFRESH',

--- a/src/hooks/useResendVerification.ts
+++ b/src/hooks/useResendVerification.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react';
-import axios from 'axios';
 import { toast } from 'react-toastify';
-import { BASE_URL } from '@/context/UserProvider';
+import { api } from '@/services/api';
 
 export const useResendVerification = () => {
     const [resending, setResending] = useState(false);
@@ -9,7 +8,7 @@ export const useResendVerification = () => {
     const resendEmail = async (email: string) => {
         setResending(true);
         try {
-            await axios.post(`${BASE_URL}/auth/resend-verification`, { email });
+            await api.post('/auth/resend-verification', { email }, { skipErrorToast: true } as any);
             toast.success("A new link has been dispatched!");
             return true;
         } catch (err: any) {

--- a/src/hooks/useResetPassword.ts
+++ b/src/hooks/useResetPassword.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
-import axios from "axios";
 import { toast } from "react-toastify";
-import { BASE_URL } from "@/context/UserProvider";
+import { api } from "@/services/api";
 
 export const useResetPassword = () => {
     const [loading, setLoading] = useState(false);
@@ -9,7 +8,7 @@ export const useResetPassword = () => {
     const resetPassword = async (resetToken: string, password: string) => {
         setLoading(true);
         try {
-            await axios.put(`${BASE_URL}/auth/reset-password/${resetToken}`, { password });
+            await api.put(`/auth/reset-password/${resetToken}`, { password }, { skipErrorToast: true } as any);
             toast.success("Password reset successful! Please log in.");
             return true;
         } catch (error: any) {

--- a/src/hooks/useSharedHospitals.ts
+++ b/src/hooks/useSharedHospitals.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
-import axios from "axios";
 import { Hospital } from "@/types/hospital";
-import { BASE_URL } from "@/context/UserProvider";
+import { api } from "@/services/api";
 
 export const useSharedHospitals = (linkId: string | undefined) => {
     const [hospitalList, setHospitalList] = useState<Hospital[]>([]);
@@ -20,7 +19,8 @@ export const useSharedHospitals = (linkId: string | undefined) => {
             setError("");
 
             try {
-                const { data } = await axios.get(`${BASE_URL}/hospitals/share/${encodeURIComponent(linkId)}`);
+                const response = await api.get(`/hospitals/share/${encodeURIComponent(linkId)}`, { skipErrorToast: true } as any);
+                const data = response.data;
                 setHospitalList(Array.isArray(data) ? data : []);
             } catch (err: any) {
                 console.error("Shared List Fetch Error:", err);

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -11,7 +11,7 @@ const useSignup = () => {
     setLoading(true);
 
     try {
-      const response = await api.post(`/auth/register`, user);
+      const response = await api.post(`/auth/register`, user, { skipErrorToast: true } as any);
 
      toast.success(response.data.message || "Account created! Verify your email.", {
         position: "top-center"

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -10,7 +10,7 @@ export const useStats = () => {
     const fetchStats = async () => {
         try {
             setLoading(true);
-            const { data } = await axiosPrivate.get("/user/stats");
+            const { data } = await axiosPrivate.get("/user/stats", { skipErrorToast: true } as any);
             setStats(data);
             setError(false);
         } catch (err) {

--- a/src/hooks/useSubmitHospital.ts
+++ b/src/hooks/useSubmitHospital.ts
@@ -14,7 +14,7 @@ export const useSubmitHospital = () => {
     setShowSuccess(false);
 
     try {
-      await axiosPrivate.post(`/hospitals`, payload);
+      await axiosPrivate.post(`/hospitals`, payload, { skipErrorToast: true } as any);
       setShowSuccess(true);
       return true;
     } catch (err: any) {

--- a/src/hooks/useSymptomMappings.ts
+++ b/src/hooks/useSymptomMappings.ts
@@ -11,7 +11,7 @@ export const useSymptomMappings = () => {
   const fetchMappings = useCallback(async () => {
     setIsLoading(true);
     try {
-      const { data } = await axiosPrivate.get("/admin/symptoms");
+      const { data } = await axiosPrivate.get("/admin/symptoms", { skipErrorToast: true } as any);
       setMappings(data);
     } catch (err: any) {
       toast.error("Failed to load symptom mappings.");
@@ -22,7 +22,7 @@ export const useSymptomMappings = () => {
 
   const createMapping = useCallback(async (keywords: string[], services: string[]) => {
     try {
-      const { data } = await axiosPrivate.post("/admin/symptoms", { symptomKeywords: keywords, services });
+      const { data } = await axiosPrivate.post("/admin/symptoms", { symptomKeywords: keywords, services }, { skipErrorToast: true } as any);
       setMappings(prev => [...prev, data]);
       toast.success("Symptom mapping created.");
     } catch (err: any) {
@@ -33,7 +33,7 @@ export const useSymptomMappings = () => {
 
   const updateMapping = useCallback(async (id: string, keywords: string[], services: string[]) => {
     try {
-      const { data } = await axiosPrivate.put(`/admin/symptoms/${id}`, { symptomKeywords: keywords, services });
+      const { data } = await axiosPrivate.put(`/admin/symptoms/${id}`, { symptomKeywords: keywords, services }, { skipErrorToast: true } as any);
       setMappings(prev => prev.map(m => m._id === id ? data : m));
       toast.success("Mapping updated.");
     } catch (err: any) {
@@ -44,7 +44,7 @@ export const useSymptomMappings = () => {
 
   const deleteMapping = useCallback(async (id: string) => {
     try {
-      await axiosPrivate.delete(`/admin/symptoms/${id}`);
+      await axiosPrivate.delete(`/admin/symptoms/${id}`, { skipErrorToast: true } as any);
       setMappings(prev => prev.filter(m => m._id !== id));
       toast.success("Mapping deleted.");
     } catch (err: any) {

--- a/src/hooks/useUpdatePassword.ts
+++ b/src/hooks/useUpdatePassword.ts
@@ -12,7 +12,7 @@ const usePasswordUpdate = () => {
   const updatePassword = async (user: PasswordUpdate) => {
     setLoading(true);
     try {
-      await axiosPrivate.patch(`/user/password`, user);
+      await axiosPrivate.patch(`/user/password`, user, { skipErrorToast: true } as any);
 
       toast.success("Password updated successfully!", { position: "top-center" });
       localStorage.removeItem("accessToken");

--- a/src/hooks/useUpdateUser.ts
+++ b/src/hooks/useUpdateUser.ts
@@ -12,7 +12,7 @@ const useUpdate = () => {
   const update = async (user: User, onSuccess?: () => void) => {
     setLoading(true);
     try {
-      const response = await axiosPrivate.patch<User>(`/user`, user);
+      const response = await axiosPrivate.patch<User>(`/user`, user, { skipErrorToast: true } as any);
 
       dispatch({
         type: 'UPDATE',

--- a/src/hooks/useUserActivity.ts
+++ b/src/hooks/useUserActivity.ts
@@ -6,7 +6,7 @@ export const useUserActivity = () => {
 
   const syncFavorite = async (hospitalId: string) => {
     try {
-      await axiosPrivate.post("/user/favorites", { hospitalId });
+      await axiosPrivate.post("/user/favorites", { hospitalId }, { skipErrorToast: true } as any);
     } catch (err) {
       console.error("Background Sync Error (Fav):", err);
     }
@@ -14,7 +14,7 @@ export const useUserActivity = () => {
 
   const syncView = async (hospitalId: string) => {
     try {
-      return await axiosPrivate.post("/user/view", { hospitalId });
+      return await axiosPrivate.post("/user/view", { hospitalId }, { skipErrorToast: true } as any);
     } catch (err) {
       console.error("Background Sync Error (View):", err);
     }
@@ -22,7 +22,7 @@ export const useUserActivity = () => {
 
   const fetchActivity = async () => {
     try {
-      const { data } = await axiosPrivate.get("/user/activity");
+      const { data } = await axiosPrivate.get("/user/activity", { skipErrorToast: true } as any);
       return data;
     } catch (err) {
       console.error("Hydration Error:", err);
@@ -32,7 +32,7 @@ export const useUserActivity = () => {
 
   const removeFavoriteItem = async (id: string): Promise<boolean> => {
     try {
-      await axiosPrivate.delete(`/user/favorites/${id}`);
+      await axiosPrivate.delete(`/user/favorites/${id}`, { skipErrorToast: true } as any);
       toast.success("Removed from saved collections");
       return true;
     } catch (err: any) {
@@ -44,7 +44,7 @@ export const useUserActivity = () => {
 
   const removeHistoryItem = async (id: string): Promise<boolean> => {
     try {
-      await axiosPrivate.delete(`/user/history/${id}`);
+      await axiosPrivate.delete(`/user/history/${id}`, { skipErrorToast: true } as any);
       toast.success("Removed from recent history");
       return true;
     } catch (err: any) {

--- a/src/hooks/useUserSubmissions.ts
+++ b/src/hooks/useUserSubmissions.ts
@@ -18,7 +18,7 @@ export const useUserSubmissions = () => {
             setLoading(true);
             setError(false);
 
-            const { data } = await axiosPrivate.get("/hospitals/submissions");
+            const { data } = await axiosPrivate.get("/hospitals/submissions", { skipErrorToast: true } as any);
             const validData = Array.isArray(data) ? data : [];
 
             setSubmissions(validData);

--- a/src/hooks/useVerifyEmail.ts
+++ b/src/hooks/useVerifyEmail.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
-import axios from "axios";
-import { BASE_URL, useAuthContext } from "@/context/UserProvider";
+import { useAuthContext } from "@/context/UserProvider";
+import { api } from "@/services/api";
 
 export const useVerifyEmail = () => {
     const { dispatch } = useAuthContext();
@@ -15,7 +15,7 @@ export const useVerifyEmail = () => {
         }
 
         try {
-            const response = await axios.get(`${BASE_URL}/auth/verify-email?token=${token}`);
+            const response = await api.get(`/auth/verify-email?token=${token}`, { skipErrorToast: true } as any);
             const authData = response.data;
 
             localStorage.setItem("accessToken", authData.accessToken);

--- a/src/pages/about/about.tsx
+++ b/src/pages/about/about.tsx
@@ -13,7 +13,7 @@ import PhoneMap from "@/assets/images/phone.jpg";
 import style from "./styles/about.module.scss";
 
 const About = () => {
-  const { totalHospitals, totalCountries, loading } = useGlobalStats();
+  const { totalHospitals, totalCountries, loading, error, retry } = useGlobalStats();
 
   return (
     <>
@@ -40,18 +40,29 @@ const About = () => {
             <div className={style.statsRow}>
               <div className={style.statItem}>
                 <span className={style.statNumber}>
-                  {loading ? "..." : totalHospitals ? `${totalHospitals.toLocaleString()}+` : "500+"}
+                  {loading && "..."}
+                  {!loading && error && "--"}
+                  {!loading && !error && totalHospitals !== null && `${totalHospitals.toLocaleString()}+`}
                 </span>
                 <span className={style.statLabel}>Verified Facilities</span>
               </div>
               <div className={style.divider}></div>
               <div className={style.statItem}>
                 <span className={style.statNumber}>
-                  {loading ? "..." : totalCountries ? `${totalCountries}+` : "50+"}
+                  {loading && "..."}
+                  {!loading && error && "--"}
+                  {!loading && !error && totalCountries !== null && `${totalCountries}+`}
                 </span>
                 <span className={style.statLabel}>Countries Covered</span>
               </div>
             </div>
+
+            {error && (
+              <div className={style.errorRetry}>
+                <p>Could not load platform stats.</p>
+                <button onClick={retry} className={style.retryBtn}>Retry</button>
+              </div>
+            )}
 
             <Link to="/find-hospital" className={style.ctaLink}>
               Locate a Facility

--- a/src/pages/about/styles/about.module.scss
+++ b/src/pages/about/styles/about.module.scss
@@ -99,7 +99,7 @@ h2, .heading {
       display: flex;
       align-items: center;
       gap: 2rem;
-      margin-bottom: 2.5rem;
+      margin-bottom: 1rem;
       padding: 1.5rem;
       background: var(--color-white);
       border-radius: 16px;
@@ -146,6 +146,37 @@ h2, .heading {
         }
       }
     }
+
+    // Error handling for stats
+.errorRetry {
+  margin-bottom: 2.5rem;
+  color: var(--text-slate);
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+
+  p {
+    margin: 0;
+  }
+}
+
+.retryBtn {
+  background: none;
+  border: none;
+  color: var(--color-blue);
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 0.95rem;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  padding: 0;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
 
     .ctaLink {
   display: inline-flex;

--- a/src/pages/directory/countryRegistry.tsx
+++ b/src/pages/directory/countryRegistry.tsx
@@ -26,6 +26,7 @@ const CountryRegistry: React.FC = () => {
     totalPages,
     page,
     decodedCountry,
+    error, retry,
     loadMore
   } = useCountryHospitals(country);
 
@@ -111,9 +112,16 @@ const CountryRegistry: React.FC = () => {
           </section>
 
           <section className={style.contentSection}>
-            {loading && page === 1 ? (
+            {error && (
+              <div className={style.errorState}>
+                <p>Could not load hospitals for {decodedCountry}.</p>
+                <button onClick={retry} className={style.retryBtn}>Retry</button>
+              </div>
+            )}
+
+            {!error && loading && page === 1 ? (
               <AnimatedLoader message={`Syncing ${decodedCountry} records...`} variant="card" count={6} />
-            ) : filteredHospitals.length === 0 ? (
+            ) : !error && filteredHospitals.length === 0 ? (
               <div className={style.emptyState}>
                 <FiSearch size={40} className={style.emptyIcon} />
                 <h2 className={style.emptyStateTitle}>No Facilities Found</h2>
@@ -122,7 +130,7 @@ const CountryRegistry: React.FC = () => {
                   Clear Search/Filter
                 </button>
               </div>
-            ) : (
+              ) : !error && (
               <div className={style.grid}>
                 {filteredHospitals.map((h, i) => (
                   <div

--- a/src/pages/directory/globalDirectory.tsx
+++ b/src/pages/directory/globalDirectory.tsx
@@ -14,7 +14,7 @@ const CONTINENTS = ["All", "Africa", "Americas", "Asia", "Europe", "Oceania"];
 const GlobalDirectory = () => {
   const [query, setQuery] = useState("");
   const [selectedContinent, setSelectedContinent] = useState("All");
-  const { unifiedCountries, loading } = useGlobalDirectory();
+  const { unifiedCountries, loading, error, retry } = useGlobalDirectory();
 
   const filtered = useMemo(() => {
     return unifiedCountries.filter((c) => {
@@ -81,11 +81,18 @@ const GlobalDirectory = () => {
           </section>
 
           <section className={style.contentSection}>
-            {loading ? (
+            {error && (
+              <div className={style.errorState}>
+                <p>Could not load the global directory.</p>
+                <button onClick={retry} className={style.retryBtn}>Retry</button>
+              </div>
+            )}
+
+            {!error && loading ?(
               <div className={style.loaderWrapper}>
                 <AnimatedLoader message="Retrieving global index..." variant="card" count={8} />
               </div>
-            ) : filtered.length === 0 ? (
+            ) : !error && filtered.length === 0 ? (
               <Motion as="div" className={style.emptyState} variants={fadeUp}>
                 <div className={style.emptyIcon}><FiMapPin /></div>
                 <h2 className={style.emptyStateTitle}>No Matching Regions Found</h2>
@@ -94,7 +101,7 @@ const GlobalDirectory = () => {
                   Clear Search
                 </button>
               </Motion>
-            ) : (
+              ) : !error && (
               <div className={style.grid}>
                 {filtered.map(({ country, hospitals }) => (
                   <Motion

--- a/src/pages/directory/styles/countryRegistry.module.css
+++ b/src/pages/directory/styles/countryRegistry.module.css
@@ -189,6 +189,38 @@
   margin-top: 3rem;
 }
 
+.errorState {
+  text-align: center;
+  padding: 4rem 2rem;
+  background: var(--color-bg);
+  border-radius: 1.5rem;
+  border: 1px dashed var(--color-border);
+  max-width: 500px;
+  margin: 0 auto;
+  color: var(--color-gray);
+}
+
+.errorState p {
+  margin-bottom: 1.5rem;
+  font-size: 1.2rem;
+}
+
+.retryBtn {
+  background: var(--color-blue);
+  color: var(--color-white);
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 2rem;
+  font-weight: 600;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.retryBtn:hover {
+  background: var(--color-blue-dark);
+}
+
 .emptyState {
   text-align: center;
   padding: 5rem 2rem;

--- a/src/pages/directory/styles/globalDirectory.module.css
+++ b/src/pages/directory/styles/globalDirectory.module.css
@@ -184,6 +184,39 @@
   margin-top: 3rem;
 }
 
+.errorState {
+  text-align: center;
+  padding: 5rem 2rem;
+  background: var(--color-bg);
+  border-radius: 1.5rem;
+  border: 1px dashed var(--color-border);
+  max-width: 550px;
+  margin: 0 auto;
+  color: var(--color-gray);
+}
+
+.errorState p {
+  margin-bottom: 1.5rem;
+  font-size: 1.2rem;
+}
+
+.retryBtn {
+  background: var(--color-blue);
+  color: var(--color-white);
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 2rem;
+  font-weight: 600;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s;
+  font-family: var(--font-inter);
+}
+
+.retryBtn:hover {
+  background: var(--color-blue-dark);
+}
+
 .loaderWrapper {
   margin-top: 2rem;
 }

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -109,17 +109,17 @@ const Home = () => {
           <div className={style.statsBar}>
             <div className={style.statItem}>
               <span className={style.statValue}>
-                {!loading && !error && totalHospitals !== null
-                  ? `${totalHospitals.toLocaleString()}+`
-                  : <div className={style.shimmer} aria-busy="true" />}
+                {loading && <div className={style.shimmer} aria-busy="true" />}
+                {!loading && error && <span className={style.errorValue}>--</span>}
+                {!loading && !error && totalHospitals !== null && `${totalHospitals.toLocaleString()}+`}
               </span>
               <span className={style.statLabel}>Verified Hospitals</span>
             </div>
             <div className={style.statItem}>
               <span className={style.statValue}>
-                {!loading && !error && totalCountries !== null
-                  ? `${totalCountries}+`
-                  : <div className={style.shimmer} aria-busy="true" />}
+                {loading && <div className={style.shimmer} aria-busy="true" />}
+                {!loading && error && <span className={style.errorValue}>--</span>}
+                {!loading && !error && totalCountries !== null && `${totalCountries}+`}
               </span>
               <span className={style.statLabel}>Countries Covered</span>
             </div>
@@ -129,6 +129,15 @@ const Home = () => {
             </div>
           </div>
         </Motion>
+
+        {error && (
+          <div className={style.errorRetry}>
+            <p>Could not load hospital stats.</p>
+            <button onClick={() => window.location.reload()} className={style.retryBtn}>
+              Retry
+            </button>
+          </div>
+        )}
 
         <Motion variants={fadeUp} as="section" once={true}>
           <div className={style.howSection}>

--- a/src/pages/home/styles/home.module.scss
+++ b/src/pages/home/styles/home.module.scss
@@ -242,6 +242,37 @@
     letter-spacing: 0.05em;
   }
 
+  .errorValue {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #6b7280;
+}
+
+.errorRetry {
+  text-align: center;
+  margin: 1rem 0;
+  color: #a0a8c0;
+
+  p {
+    margin-bottom: 0.5rem;
+  }
+}
+
+.retryBtn {
+  background: #4ea8de;
+  color: #0a0f1a;
+  border: none;
+  padding: 0.5rem 1.5rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #64b5e8;
+  }
+}
+
 
   .howSection {
     padding: 5rem 0 1rem;

--- a/src/pages/profile/accountStats.tsx
+++ b/src/pages/profile/accountStats.tsx
@@ -3,7 +3,7 @@ import { useStats } from "@/hooks/useStats";
 import styles from "./styles/scss/accountStats/accountStats.module.scss";
 
 const AccountStats = () => {
-    const { stats, loading, error } = useStats();
+    const { stats, loading, error, refresh } = useStats();
 
     if (loading) {
         return (
@@ -13,7 +13,16 @@ const AccountStats = () => {
         );
     }
 
-    if (error) return null;
+    if (error) {
+        return (
+            <div className={styles.statsGrid}>
+                <div className={styles.errorCard}>
+                    <p className={styles.errorText}>Could not load your contribution stats.</p>
+                    <button onClick={refresh} className={styles.retryBtn}>Retry</button>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className={styles.statsGrid}>

--- a/src/pages/profile/styles/scss/accountStats/accountStats.module.scss
+++ b/src/pages/profile/styles/scss/accountStats/accountStats.module.scss
@@ -113,6 +113,44 @@
     border-radius: 1.5rem;
 }
 
+.errorCard {
+  flex: 1 1 0;
+  min-width: 220px;
+  background: var(--color-white);
+  border: 1px dashed var(--color-error);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  color: var(--color-gray);
+}
+
+.errorText {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.retryBtn {
+  background: var(--color-blue);
+  color: var(--color-white);
+  border: none;
+  padding: 0.6rem 1.5rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s;
+  font-family: var(--font-inter);
+
+  &:hover {
+    background: var(--color-blue-dark);
+  }
+}
+
 .verifiedBadge {
     font-size: 0.85rem;
     font-weight: 700;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,121 +1,28 @@
 import axios from "axios";
+import { toast } from "react-toastify";
 import { BASE_URL } from "@/context/UserProvider";
 import { Hospital } from "@/types/hospital";
 
-export async function getHospitals() {
-  try {
-    const response = await axios.get(`${BASE_URL}/hospitals`);
-    const hospitals = response.data
-    return hospitals;
-  } catch (error) {
-    throw error
+const getErrorMessage = (error: any): string => {
+  // Zod validation errors from backend
+  if (error?.response?.data?.errors?.length > 0) {
+    return error.response.data.errors[0].message;
   }
-}
-
-// get hospital details by id or slug
-export async function getHospitalDetails(params: any) {
-  try {
-    if (params.slug) {
-      const response = await axios.get(
-        `${BASE_URL}/hospitals/${params.country}/${params.city}/${params.slug}`
-      );
-      return response.data;
-    }
-
-    const response = await axios.get(`${BASE_URL}/hospitals/${params.id}`);
-    return response.data;
-
-  } catch (error) {
-    throw error;
+  // Standard backend message
+  if (error?.response?.data?.message) {
+    return error.response.data.message;
   }
-}
-
-export async function getRandomHospitals() {
-  try {
-    const response = await axios.get(`${BASE_URL}/hospitals/random`);
-    const randomHospital = response.data;
-    return randomHospital;
-  } catch (error) {
-    throw error
+  // Network error (no response)
+  if (error.code === "ERR_NETWORK" || !error.response) {
+    return "Network error. Please check your connection.";
   }
-}
-
-export async function getHospitalByName(name: string) {
-  try {
-    const response = await axios.get(`${BASE_URL}/hospitals/${name}`);
-    const hospital = response.data;
-    return hospital;
-  } catch (error) {
-    throw error
+  // Timeout
+  if (error.code === "ECONNABORTED") {
+    return "Request timed out. Please try again.";
   }
-}
-
-export async function findHospitals(query: string) {
-  try {
-    const response = await axios.get(`${BASE_URL}/hospitals/find?${query}`);
-    return response.data;
-  } catch (error) {
-    throw error;
-  }
-}
-
-export const shareHospital = async (searchParams: any) => {
-  try {
-    const response = await axios.post(`${BASE_URL}/hospitals/share`, { searchParams });
-
-    if (response.data && response.data.linkId) {
-        return response.data.linkId;
-    }
-
-    return response.data;
-  } catch (error) {
-    throw error;
-  }
+  // Fallback
+  return "Something went wrong. Please try again.";
 };
-
-export async function exportHospital(searchParams: any) {
-  try {
-    const { data } = await axios.get(`${BASE_URL}/hospitals/export`, {
-      responseType: "blob",
-      params: searchParams
-    });
-    console.log(searchParams)
-    const exportedData = data;
-    return exportedData;
-  } catch (error) {
-    throw error
-  }
-}
-
-export async function addHospital(hospital: Hospital) {
-  try {
-    const response = await axios.post(`${BASE_URL}/hospitals`, hospital);
-    const newHospital = response.data;
-    return newHospital;
-  } catch (error) {
-    throw error
-  }
-}
-
-export async function updateHospital(hospital: Hospital, id: number) {
-  try {
-    const response = await axios.patch(`${BASE_URL}/hospitals/${id}`, hospital);
-    const updatedHospital = response.data;
-    return updatedHospital;
-  } catch (error) {
-    throw error
-  }
-}
-
-export async function deleteHospital(id: number) {
-  try {
-    const response = await axios.delete(`${BASE_URL}/hospitals/${id}`);
-    const deletedHospital = response.data;
-    return deletedHospital;
-  } catch (error) {
-    throw error
-  }
-}
 
 // axios api
 let activeRequests = 0;
@@ -157,5 +64,117 @@ api.interceptors.response.use((response) => {
     return response;
 }, (error) => {
     hideLoader();
+      // Show error toast unless the request explicitly opts out
+    if (!error.config?.skipErrorToast) {
+      toast.error(getErrorMessage(error));
+    }
     return Promise.reject(error);
 });
+
+export async function getHospitals() {
+  try {
+    const response = await api.get("/hospitals", { skipErrorToast: true } as any);
+    const hospitals = response.data
+    return hospitals;
+  } catch (error) {
+    throw error
+  }
+}
+
+// get hospital details by id or slug
+export async function getHospitalDetails(params: any) {
+  try {
+    if (params.slug) {
+      const response = await api.get(
+        `/hospitals/${params.country}/${params.city}/${params.slug}`,
+        { skipErrorToast: true } as any
+      );
+      return response.data;
+    }
+
+    const response = await api.get(`/hospitals/${params.id}`, { skipErrorToast: true } as any);
+    return response.data;
+
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function getRandomHospitals() {
+  try {
+    const response = await api.get("/hospitals/random", { skipErrorToast: true } as any);
+    const randomHospital = response.data;
+    return randomHospital;
+  } catch (error) {
+    throw error
+  }
+}
+
+export async function getHospitalByName(name: string) {
+  try {
+    const response = await api.get(`/hospitals/${name}`, { skipErrorToast: true } as any);
+    const hospital = response.data;
+    return hospital;
+  } catch (error) {
+    throw error
+  }
+}
+
+export const shareHospital = async (searchParams: any) => {
+  try {
+    const response = await api.post(`/hospitals/share`, { searchParams }, { skipErrorToast: true } as any);
+
+    if (response.data && response.data.linkId) {
+        return response.data.linkId;
+    }
+
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export async function exportHospital(searchParams: any) {
+  try {
+    const { data } = await api.get(`/hospitals/export`, {
+      responseType: "blob",
+      params: searchParams,
+      skipErrorToast: true,
+      } as any)
+
+    const exportedData = data;
+    return exportedData;
+  } catch (error) {
+    throw error
+  }
+}
+
+export async function addHospital(hospital: Hospital) {
+  try {
+    const response = await api.post("/hospitals", hospital, { skipErrorToast: true } as any);
+    const newHospital = response.data;
+    return newHospital;
+  } catch (error) {
+    throw error
+  }
+}
+
+export async function updateHospital(hospital: Hospital, id: number) {
+  try {
+    const response = await api.patch(`/hospitals/${id}`, hospital, { skipErrorToast: true } as any);
+    const updatedHospital = response.data;
+    return updatedHospital;
+  } catch (error) {
+    throw error
+  }
+}
+
+export async function deleteHospital(id: number) {
+  try {
+    const response = await api.delete(`/hospitals/${id}`, { skipErrorToast: true } as any);
+    const deletedHospital = response.data;
+    return deletedHospital;
+  } catch (error) {
+    throw error
+  }
+}


### PR DESCRIPTION
- Add global Axios response interceptor with user‑friendly toasts
- Introduce skipErrorToast opt‑out for components with custom error UI
- Add inline error states and retry buttons to Home, About, NearbyHospitals, GlobalDirectory, CountryRegistry, HospitalDetails, PopularHospitals, AccountStats
- Migrate all raw fetch/axios calls to shared api instance with skipErrorToast
- Refactor health hooks (useHealthTips, useHealthNews, useOutbreaks) to use api
- Eliminate duplicate toast notifications across all hooks and pages
- Extract share page styles into separate CSS module
- Reorganize api.ts: define api instance before exported functions